### PR TITLE
Update UnicalApiEventsResource.class.php

### DIFF
--- a/plugins/restful/UnicalApiEventsResource.class.php
+++ b/plugins/restful/UnicalApiEventsResource.class.php
@@ -5,7 +5,7 @@
  * Defines events REST resource.
  */
 
-require 'UnicalApiEventsFields.class.php';
+require_once 'UnicalApiEventsFields.class.php';
 
 /**
  * Extend fields.


### PR DESCRIPTION
Change this to require_once so that UnicalApiEventsFields.class.php can be require_once'ed in other files to extend the fields with other info. This prevents UnicalApiEventsFields from being re-declared during weird moments like enabling/disabling modules and clearing caches.